### PR TITLE
browserify support - re-enable buffer polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
     "browserify": "^14.1.0",
     "tape": "^4.6.3",
     "uglify-js": "^2.6.1"
-  },
-  "browser": {
-    "buffer": false
   }
 }


### PR DESCRIPTION
Fixes https://github.com/dchest/tweetnacl-util-js/issues/9

Re-add support for browserify builds