### PR TITLE
fix validateBase64 to large strings

### DIFF
--- a/nacl-util.js
+++ b/nacl-util.js
@@ -14,7 +14,7 @@
   var util = {};
 
   function validateBase64(s) {
-    if (!(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(s))) {
+    if (!(/^(?:[A-Za-z0-9+\/]{2}[A-Za-z0-9+\/]{2})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/.test(s))) {
       throw new TypeError('invalid encoding');
     }
   }


### PR DESCRIPTION
fix maximum call stack exceeded on "validateBase64" to large strings